### PR TITLE
fix missing topology.Cells() and speedup for TopologicCore

### DIFF
--- a/Python-Bindings/src/Topology.cppwg.cpp
+++ b/Python-Bindings/src/Topology.cppwg.cpp
@@ -441,6 +441,16 @@ py::class_<Topology , Topology_Overloads , std::shared_ptr<Topology >  , Topolog
             " ", py::arg("rWires"))
 
         .def(
+            "Cells",
+            [](const Topology& obj, py::list& rCells) {
+                std::list<Cell::Ptr> local;
+                obj.Cells(local);
+                for (auto& x : local)
+                    rCells.append(x);
+            },
+            " ", py::arg("rCells"))
+
+        .def(
             "UpwardNavigation", 
             (void(Topology::*)(::TopoDS_Shape const &, int const, ::std::list<std::shared_ptr<TopologicCore::Topology>, std::allocator<std::shared_ptr<TopologicCore::Topology>>> &) const ) &Topology::UpwardNavigation, 
             " " , py::arg("rkOcctHostTopology"), py::arg("kTopologyType"), py::arg("rAncestors") )

--- a/TopologicCore/src/Vertex.cpp
+++ b/TopologicCore/src/Vertex.cpp
@@ -46,7 +46,7 @@ namespace TopologicCore
 		TopoDS_Vertex occtVertex = BRepBuilderAPI_MakeVertex(pOcctPoint->Pnt());
 		TopoDS_Vertex occtFixedVertex = TopoDS::Vertex(Topology::FixShape(occtVertex));
 		Vertex::Ptr pVertex = std::make_shared<Vertex>(occtFixedVertex);
-		GlobalCluster::GetInstance().AddTopology(pVertex->GetOcctVertex());
+		//GlobalCluster::GetInstance().AddTopology(pVertex->GetOcctVertex());
 		return pVertex;
 	}
 
@@ -55,7 +55,7 @@ namespace TopologicCore
 		TopoDS_Vertex occtVertex = BRepBuilderAPI_MakeVertex(gp_Pnt(kX, kY, kZ));
 		TopoDS_Vertex occtFixedVertex = TopoDS::Vertex(Topology::FixShape(occtVertex));
 		Vertex::Ptr pVertex = std::make_shared<Vertex>(occtFixedVertex);
-		GlobalCluster::GetInstance().AddTopology(pVertex->GetOcctVertex());
+		//GlobalCluster::GetInstance().AddTopology(pVertex->GetOcctVertex());
 		return pVertex;
 	}
 


### PR DESCRIPTION
There are two patches here: one adds a missing Cells() method to the python API; and the other comments-out a couple of lines that slow the library down by about 30% here (I have been using TopologicCore with this modification for months without problems).