### PR TITLE
Fix build scripts for TopologicPythonBindings

### DIFF
--- a/TopologicPythonBindings/build_linux.py
+++ b/TopologicPythonBindings/build_linux.py
@@ -5,10 +5,10 @@ import sysconfig
 
 
 def find_wheel(pa_dir, name):
-    # construct the wheel file name using the sysconfig vars VERSION and EXT_SUFFIX and using glob
-    py_version = sysconfig.get_config_var("VERSION")
-    abi_tag = sysconfig.get_config_var('EXT_SUFFIX').split(".")[1]
-    wheel_pattern = f"{name}-*-*{py_version}-{abi_tag}.whl"
+    # construct a glob pattern for the wheel file name using sysconfig.get_platform() as the abi tag
+    py_version = f"{sys.version_info.major}{sys.version_info.minor}"
+    abi_tag = sysconfig.get_platform().replace("-", "_")
+    wheel_pattern = f"{name}-*-*{py_version}-*{abi_tag}.whl"
 
     wheels = glob.glob(os.path.join(pa_dir, wheel_pattern))
     if len(wheels) == 0:

--- a/TopologicPythonBindings/build_macos.py
+++ b/TopologicPythonBindings/build_macos.py
@@ -5,10 +5,12 @@ import sysconfig
 
 
 def find_wheel(pa_dir, name):
-    # construct the wheel file name using the sysconfig vars VERSION and EXT_SUFFIX and using glob
-    py_version = sysconfig.get_config_var("VERSION")
-    abi_tag = sysconfig.get_config_var('EXT_SUFFIX').split(".")[1]
-    wheel_pattern = f"{name}-*-*{py_version}-{abi_tag}.whl"
+    # construct a glob pattern for the wheel file name using sysconfig.get_platform() as the abi tag
+    py_version = f"{sys.version_info.major}{sys.version_info.minor}"
+    abi_tag = sysconfig.get_platform()
+    abi_tag = abi_tag.replace("-", "_")
+    abi_tag = abi_tag.replace(".", "_")
+    wheel_pattern = f"{name}-*-*{py_version}-*{abi_tag}.whl"
 
     wheels = glob.glob(os.path.join(pa_dir, wheel_pattern))
     if len(wheels) == 0:

--- a/TopologicPythonBindings/build_windows.py
+++ b/TopologicPythonBindings/build_windows.py
@@ -5,10 +5,10 @@ import sysconfig
 
 
 def find_wheel(pa_dir, name):
-    # construct the wheel file name using the sysconfig vars VERSION and EXT_SUFFIX and using glob
-    py_version = sysconfig.get_config_var("VERSION")
-    abi_tag = sysconfig.get_config_var('EXT_SUFFIX').split(".")[1]
-    wheel_pattern = f"{name}-*-*{py_version}-{abi_tag}.whl"
+    # construct a glob pattern for the wheel file name using sysconfig.get_platform() as the abi tag
+    py_version = f"{sys.version_info.major}{sys.version_info.minor}"
+    abi_tag = sysconfig.get_platform().replace("-", "_")
+    wheel_pattern = f"{name}-*-*{py_version}-*{abi_tag}.whl"
 
     wheels = glob.glob(os.path.join(pa_dir, wheel_pattern))
     if len(wheels) == 0:


### PR DESCRIPTION
After testing, the recent code change to support multiple wheel files for multiple Python versions didn't work on Linux, Mac.
Now tested on all systems.
