### PR TITLE
Remove the redundant kCopyAttributes param

### DIFF
--- a/TopologicCore/include/Edge.h
+++ b/TopologicCore/include/Edge.h
@@ -140,7 +140,7 @@ namespace TopologicCore
 		/// <param name="kpEndVertex">The end Vertex</param>
 		/// <param name="kCopyAttributes">If True, copy the dictionaries</param>
 		/// <returns name="Edge">The created Edge</returns>
-		TOPOLOGIC_API static Edge::Ptr ByStartVertexEndVertex(const std::shared_ptr<Vertex>& kpStartVertex, const std::shared_ptr<Vertex>& kpEndVertex, const bool kCopyAttributes = false);
+		TOPOLOGIC_API static Edge::Ptr ByStartVertexEndVertex(const std::shared_ptr<Vertex>& kpStartVertex, const std::shared_ptr<Vertex>& kpEndVertex);
 
 		/// <summary>
 		/// Returns the shared Vertices between two Edges.

--- a/TopologicCore/src/Edge.cpp
+++ b/TopologicCore/src/Edge.cpp
@@ -188,7 +188,7 @@ namespace TopologicCore
 		return pEdge;
 	}
 
-	Edge::Ptr Edge::ByStartVertexEndVertex(const std::shared_ptr<Vertex>& kpStartVertex, const std::shared_ptr<Vertex>& kpEndVertex, const bool kCopyAttributes)
+	Edge::Ptr Edge::ByStartVertexEndVertex(const std::shared_ptr<Vertex>& kpStartVertex, const std::shared_ptr<Vertex>& kpEndVertex)
 	{
 		if (kpStartVertex == nullptr || kpEndVertex == nullptr)
 		{

--- a/TopologicCore/src/Utilities/FaceUtility.cpp
+++ b/TopologicCore/src/Utilities/FaceUtility.cpp
@@ -504,7 +504,7 @@ namespace TopologicUtilities
 		TopologicCore::Vertex::Ptr vertexA = TopologicCore::Vertex::ByPoint(new Geom_CartesianPoint(pointA));
 		TopologicCore::Vertex::Ptr vertexB = TopologicCore::Vertex::ByPoint(new Geom_CartesianPoint(pointB));
 
-		TopologicCore::Edge::Ptr edge = TopologicCore::Edge::ByStartVertexEndVertex(vertexA, vertexB, false);
+		TopologicCore::Edge::Ptr edge = TopologicCore::Edge::ByStartVertexEndVertex(vertexA, vertexB);
 
 		TopologicCore::Topology::Ptr sliceResult = edge->Slice(kpFace);
 		


### PR DESCRIPTION
hi @wassimj 

The `kCopyAttributes` param in `Edge::ByStartVertexEndVertex` method is unnecessary yet.