### PR TITLE
Introduce Cleanup method

### DIFF
--- a/TopologicCore/include/Topology.h
+++ b/TopologicCore/include/Topology.h
@@ -652,6 +652,11 @@ namespace TopologicCore
 
 		TOPOLOGIC_API Dictionary GetDictionary();
 
+		/// <summary>
+		/// Clean up all resources in which are managed by this library.
+		/// </summary>
+		TOPOLOGIC_API static void Cleanup();
+
 	protected:
 		TOPOLOGIC_API Topology(const int kDimensionality, const TopoDS_Shape& rkOcctShape, const std::string& rkGuid = "");
 		TOPOLOGIC_API void AddUnionInternalStructure(const TopoDS_Shape& rkOcctShape, TopTools_ListOfShape& rUnionArguments);

--- a/TopologicCore/include/TopologyFactoryManager.h
+++ b/TopologicCore/include/TopologyFactoryManager.h
@@ -45,6 +45,8 @@ namespace TopologicCore
 
 		bool Find(const std::string& rkGuid, std::shared_ptr<TopologyFactory>& rTopologyFactory);
 
+		void ClearAll();
+
 		static std::shared_ptr<TopologyFactory> GetDefaultFactory(const TopAbs_ShapeEnum kOcctType);
 
 	protected:

--- a/TopologicCore/src/Topology.cpp
+++ b/TopologicCore/src/Topology.cpp
@@ -3509,4 +3509,11 @@ namespace TopologicCore
 		return dict;
 	}
 
+	void Topology::Cleanup()
+	{
+		AttributeManager::GetInstance().ClearAll();
+		ContentManager::GetInstance().ClearAll();
+		InstanceGUIDManager::GetInstance().ClearAll();
+		TopologyFactoryManager::GetInstance().ClearAll();
+	}
 }

--- a/TopologicCore/src/TopologyFactoryManager.cpp
+++ b/TopologicCore/src/TopologyFactoryManager.cpp
@@ -46,6 +46,11 @@ namespace TopologicCore
 		return false;
 	}
 
+	void TopologyFactoryManager::ClearAll()
+	{
+		m_topologyFactoryMap.clear();
+	}
+
 	TopologyFactory::Ptr TopologyFactoryManager::GetDefaultFactory(const TopAbs_ShapeEnum kOcctType)
 	{
 		switch (kOcctType)

--- a/TopologicPythonBindings/src/Topology.cppwg.cpp
+++ b/TopologicPythonBindings/src/Topology.cppwg.cpp
@@ -566,5 +566,9 @@ void register_Topology_class(py::module& m) {
             "GetDictionary",
             (::TopologicCore::Dictionary(Topology::*)()) & Topology::GetDictionary,
             " ")
+        .def_static(
+            "Cleanup",
+            (void(*)()) & Topology::Cleanup,
+            " ")
         ;
 }


### PR DESCRIPTION
hi @wassimj 

I'd like to introduce the `Cleanup` method to clean up all resources below in which are managed by the library.
This allows the application an opportunity to clean up the resources when they are not needed yet.
- Attributes
- Contents
- Instance GUIDs
- Topology Factories

---

I have already verified the below script, the memory in usage is constant on each loop.

```Python
import time
import topologicpy
from topologicpy.Topology import Topology
from topologicpy.CellComplex import CellComplex

filepath = '/path/to/TestJSON.json'
for i in range(4,6):
    start = time.time()
    c = CellComplex.Prism(uSides=i, vSides=i, wSides=i)
    end = time.time()
    print(i, c, "Created in", round((end-start),0), "seconds")
    start = time.time()
    cells = Topology.Cells(c)
    end = time.time()
    print("Number of Cells:", len(cells), "Derived in", round((end-start),0), "seconds")
    status = Topology.ExportToJSON(c, filepath, overwrite=True)
    print("Done exporting to JSON")
    # Import the CellComplex
    for j in range(1,6):
        start = time.time()
        c = Topology.ByJSONPath(filepath)
        Topology.Cleanup()
        end = time.time()
        print(" ", j, c, "Imported from JSON in", round((end-start),0), "seconds")
print("DONE")
```