### PR TITLE
Introduce ClearOne method

### DIFF
--- a/TopologicCore/include/InstanceGUIDManager.h
+++ b/TopologicCore/include/InstanceGUIDManager.h
@@ -46,6 +46,8 @@ namespace TopologicCore
 
 		bool Find(const TopoDS_Shape& rkOcctShape, std::string& rkGUID);
 
+		void ClearOne(const TopoDS_Shape& rkOcctShape);
+
 		void ClearAll();
 
 	protected:

--- a/TopologicCore/include/Topology.h
+++ b/TopologicCore/include/Topology.h
@@ -653,9 +653,15 @@ namespace TopologicCore
 		TOPOLOGIC_API Dictionary GetDictionary();
 
 		/// <summary>
-		/// Clean up all resources in which are managed by this library.
+		/// Clean up all resources in which are managed by this library or all resources belonging to a single topology
 		/// </summary>
-		TOPOLOGIC_API static void Cleanup();
+		TOPOLOGIC_API static void Cleanup(const Topology::Ptr& kpTopology = nullptr);
+
+		/// <summary>
+		/// Clean up all resources belonging to a single topology
+		/// </summary>
+		/// <param name="kpTopology"></param>
+		TOPOLOGIC_API static void CleanOne(const Topology::Ptr& kpTopology);
 
 	protected:
 		TOPOLOGIC_API Topology(const int kDimensionality, const TopoDS_Shape& rkOcctShape, const std::string& rkGuid = "");

--- a/TopologicCore/include/TopologyFactoryManager.h
+++ b/TopologicCore/include/TopologyFactoryManager.h
@@ -45,6 +45,8 @@ namespace TopologicCore
 
 		bool Find(const std::string& rkGuid, std::shared_ptr<TopologyFactory>& rTopologyFactory);
 
+		void ClearOne(const std::string& rkGuid);
+
 		void ClearAll();
 
 		static std::shared_ptr<TopologyFactory> GetDefaultFactory(const TopAbs_ShapeEnum kOcctType);

--- a/TopologicCore/src/InstanceGUIDManager.cpp
+++ b/TopologicCore/src/InstanceGUIDManager.cpp
@@ -41,6 +41,14 @@ namespace TopologicCore
 		return false;
 	}
 
+	void InstanceGUIDManager::ClearOne(const TopoDS_Shape& rkOcctShape)
+	{
+		if (m_occtShapeToGUIDMap.find(rkOcctShape) != m_occtShapeToGUIDMap.end())
+		{
+			m_occtShapeToGUIDMap.erase(rkOcctShape);
+		}
+	}
+
 	void InstanceGUIDManager::ClearAll()
 	{
 		m_occtShapeToGUIDMap.clear();

--- a/TopologicCore/src/Topology.cpp
+++ b/TopologicCore/src/Topology.cpp
@@ -3509,12 +3509,37 @@ namespace TopologicCore
 		return dict;
 	}
 
-	void Topology::Cleanup()
+	void Topology::Cleanup(const Topology::Ptr& kpTopology)
 	{
-		AttributeManager::GetInstance().ClearAll();
-		ContentManager::GetInstance().ClearAll();
-		ContextManager::GetInstance().ClearAll();
-		InstanceGUIDManager::GetInstance().ClearAll();
-		TopologyFactoryManager::GetInstance().ClearAll();
+		if (kpTopology)
+		{
+			CleanOne(kpTopology);
+		}
+		else
+		{
+			AttributeManager::GetInstance().ClearAll();
+			ContentManager::GetInstance().ClearAll();
+			ContextManager::GetInstance().ClearAll();
+			InstanceGUIDManager::GetInstance().ClearAll();
+			TopologyFactoryManager::GetInstance().ClearAll();
+		}
+	}
+
+	void Topology::CleanOne(const Topology::Ptr& kpTopology)
+	{
+		// Sanity check
+		if (!kpTopology)
+		{
+			return;
+		}
+
+		TopoDS_Shape occtShape = kpTopology->GetOcctShape();
+		std::string kGuid = kpTopology->GetClassGUID();
+
+		AttributeManager::GetInstance().ClearOne(occtShape);
+		ContentManager::GetInstance().ClearOne(occtShape);
+		ContextManager::GetInstance().ClearOne(occtShape);
+		InstanceGUIDManager::GetInstance().ClearOne(occtShape);
+		TopologyFactoryManager::GetInstance().ClearOne(kGuid);
 	}
 }

--- a/TopologicCore/src/Topology.cpp
+++ b/TopologicCore/src/Topology.cpp
@@ -3513,6 +3513,7 @@ namespace TopologicCore
 	{
 		AttributeManager::GetInstance().ClearAll();
 		ContentManager::GetInstance().ClearAll();
+		ContextManager::GetInstance().ClearAll();
 		InstanceGUIDManager::GetInstance().ClearAll();
 		TopologyFactoryManager::GetInstance().ClearAll();
 	}

--- a/TopologicCore/src/TopologyFactoryManager.cpp
+++ b/TopologicCore/src/TopologyFactoryManager.cpp
@@ -46,6 +46,14 @@ namespace TopologicCore
 		return false;
 	}
 
+	void TopologyFactoryManager::ClearOne(const std::string& rkGuid)
+	{
+		if (m_topologyFactoryMap.find(rkGuid) != m_topologyFactoryMap.end())
+		{
+			m_topologyFactoryMap.erase(rkGuid);
+		}
+	}
+
 	void TopologyFactoryManager::ClearAll()
 	{
 		m_topologyFactoryMap.clear();

--- a/TopologicPythonBindings/src/Topology.cppwg.cpp
+++ b/TopologicPythonBindings/src/Topology.cppwg.cpp
@@ -568,7 +568,7 @@ void register_Topology_class(py::module& m) {
             " ")
         .def_static(
             "Cleanup",
-            (void(*)()) & Topology::Cleanup,
+            (void(*)(::TopologicCore::Topology::Ptr const&)) & Topology::Cleanup,
             " ")
         ;
 }


### PR DESCRIPTION
- Fix-up: Clean up all Context objects in `Cleanup` method
- Introduce `ClearOne` method to allow cleaning up all resources belonging to a single topology.

---

I have already verified the below script with new `ClearOne` method.

```Python
import time
import topologicpy
from topologicpy.Topology import Topology
from topologicpy.CellComplex import CellComplex

filepath = '/path/to/TestJSON.json'
for i in range(4,6):
    start = time.time()
    c = CellComplex.Prism(uSides=i, vSides=i, wSides=i)
    end = time.time()
    print(i, c, "Created in", round((end-start),0), "seconds")
    start = time.time()
    cells = Topology.Cells(c)
    end = time.time()
    print("Number of Cells:", len(cells), "Derived in", round((end-start),0), "seconds")
    status = Topology.ExportToJSON(c, filepath, overwrite=True)
    print("Done exporting to JSON")
    # Import the CellComplex
    for j in range(1,6):
        start = time.time()
        c = Topology.ByJSONPath(filepath)
        Topology.ClearOne(c)
        Topology.Cleanup()
        end = time.time()
        print(" ", j, c, "Imported from JSON in", round((end-start),0), "seconds")
print("DONE")
```

