### PR TITLE
Fix incorrect directory name with packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,5 +55,5 @@ jobs:
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages-dir: all-artifacts/
+          packages-dir: dist/
           print-hash: true


### PR DESCRIPTION
Need to apply this patch to use correct directory name with packages for publishing on PyPI.