### PR TITLE
Add a CPack ZIP distributable definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,3 +13,9 @@ message("CMAKE_PROJECT_VERSION=${CMAKE_PROJECT_VERSION}")
 # Sub-projects
 add_subdirectory(TopologicCore)
 add_subdirectory(TopologicPythonBindings)
+
+SET(CPACK_SOURCE_PACKAGE_FILE_NAME "Topologic-${BUILD_VERSION}")
+SET(CPACK_SOURCE_GENERATOR "ZIP")
+SET(CPACK_SOURCE_IGNORE_FILES "\\\\.git" "/build" "/BUILD")
+
+INCLUDE(CPack)


### PR DESCRIPTION
This is a normal CMake target that can optionally be used to create a source ZIP file:

  mkdir BUILD
  cd BUILD
  cmake -DBUILD_VERSION=8.0.0 ../
  make package_source

The result is a ZIP archive that contains just the sourcecode:

  Topologic-8.0.0.zip

The advantage of this is that it will include the checked-out pybind11 submodule, the standard github ZIP download doesn't include submodules and so isn't actually any use to build the library.